### PR TITLE
Process subtitles too. Fix audio converting to vorbis sometimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Remove audio streams by language
+# Remove audio/subtitle streams by language
 
 plugin for [Unmanic](https://github.com/Unmanic)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+**<span style="color:#56adda">0.0.5</span>**
+- Process audio and subtitles
+- Change to negative metadata stream selection
 
 **<span style="color:#56adda">0.0.4</span>**
 - Update FFmpeg helper

--- a/description.md
+++ b/description.md
@@ -13,3 +13,46 @@ Three letter language codes might be required because of change to negative stre
 ```
 jp,fr
 ```
+
+#### <span style="color:blue">Write your own FFmpeg params</span>
+This free text input allows you to write any FFmpeg params that you want.
+This is for more advanced use cases where you need finer control over the file transcode.
+
+:::note
+These params are added in three different places:
+1. **MAIN OPTIONS** - After the default generic options.
+   ([Main Options Docs](https://ffmpeg.org/ffmpeg.html#Main-options))
+1. **ADVANCED OPTIONS** - After the input file has been specified.
+   ([Advanced Options Docs](https://ffmpeg.org/ffmpeg.html#Advanced-options))
+
+```
+ffmpeg \
+    -hide_banner \
+    -loglevel info \
+    <MAIN OPTIONS HERE> \
+    -i /path/to/input/video.mkv \
+    <ADVANCED OPTIONS HERE> \
+    -map 0 \
+    -map -0:m:language:jp -map -0:m:language:fr \
+    -c copy \
+    -y /path/to/output/video.mkv
+```
+:::
+
+---
+
+#### Custom FFmpeg params Examples:
+
+###### <span style="color:magenta">Set first audio track to default</span>
+**<span style="color:blue">Main options</span>**
+> *(NONE)*
+>
+**<span style="color:blue">Advanced options</span>**
+> `-disposition:a:0 default`
+
+###### <span style="color:magenta">Remove default flag from all subtitles</span>
+**<span style="color:blue">Main options</span>**
+> *(NONE)*
+>
+**<span style="color:blue">Advanced options</span>**
+> `-disposition:s 0`

--- a/description.md
+++ b/description.md
@@ -1,7 +1,9 @@
 
 Enter a comma separated list of language codes to search for during library scans and new file event triggers.
 
-Any video files with audio streams having tags that match these language codes listed here will be removed from their files.
+Any video files with audio/subtitle streams having tags that match these language codes listed here will be removed from their files.
+
+Three letter language codes might be required because of change to negative stream selection
 
 ---
 

--- a/info.json
+++ b/info.json
@@ -1,13 +1,13 @@
 {
-    "author": "Josh.5",
+    "author": "Josh.5, SenorSmartyPants",
     "compatibility": [
         1,
         2
     ],
-    "description": "Specify a list of audio languages to remove from video files.",
+    "description": "Specify a list of audio/subtitle languages to remove from video files.",
     "icon": "https://raw.githubusercontent.com/Josh5/unmanic.plugin.remove_audio_stream_by_language/master/icon.png",
-    "id": "remove_audio_stream_by_language",
-    "name": "Remove audio streams by language",
+    "id": "remove_streams_by_language",
+    "name": "Remove audio/subtitle streams by language",
     "platform": [
         "all"
     ],

--- a/info.json
+++ b/info.json
@@ -6,7 +6,7 @@
     ],
     "description": "Specify a list of audio/subtitle languages to remove from video files.",
     "icon": "https://raw.githubusercontent.com/Josh5/unmanic.plugin.remove_audio_stream_by_language/master/icon.png",
-    "id": "remove_streams_by_language",
+    "id": "remove_stream_by_language",
     "name": "Remove audio/subtitle streams by language",
     "platform": [
         "all"

--- a/plugin.py
+++ b/plugin.py
@@ -33,14 +33,43 @@ logger = logging.getLogger("Unmanic.Plugin.remove_audio_stream_by_language")
 
 class Settings(PluginSettings):
     settings = {
-        "languages": ''
-    }
-    form_settings = {
-        "languages": {
-            "label": "Languages to remove",
-        },
+        "languages": '',
+        "advanced":              False,
+        "main_options":          '',
+        "advanced_options":      ''
     }
 
+
+    def __init__(self, *args, **kwargs):
+        super(Settings, self).__init__(*args, **kwargs)
+        self.form_settings = {
+            "languages": {
+                "label": "Languages to remove",
+            },
+            "advanced": {
+                "label": "Write your own FFmpeg params",
+            },
+            "main_options":          self.__set_main_options_form_settings(),
+            "advanced_options":      self.__set_advanced_options_form_settings()
+        }
+
+    def __set_main_options_form_settings(self):
+        values = {
+            "label":      "Write your own main options",
+            "input_type": "textarea",
+        }
+        if not self.get_setting('advanced'):
+            values["display"] = 'hidden'
+        return values
+
+    def __set_advanced_options_form_settings(self):
+        values = {
+            "label":      "Write your own advanced options",
+            "input_type": "textarea",
+        }
+        if not self.get_setting('advanced'):
+            values["display"] = 'hidden'
+        return values
 
 class PluginStreamMapper(StreamMapper):
     def __init__(self):
@@ -176,6 +205,10 @@ def on_worker_process(data):
     if mapper.streams_need_processing():
         # Set the output file
         mapper.set_output_file(data.get('file_out'))
+
+        if settings.get_setting('advanced'):
+            mapper.main_options += settings.get_setting('main_options').split()
+            mapper.advanced_options += settings.get_setting('advanced_options').split()
 
         # clear stream mappings, copy everything
         mapper.stream_mapping = ['-map', '0']

--- a/plugin.py
+++ b/plugin.py
@@ -25,10 +25,10 @@ import logging
 
 from unmanic.libs.unplugins.settings import PluginSettings
 
-from remove_audio_stream_by_language.lib.ffmpeg import StreamMapper, Probe, Parser
+from remove_stream_by_language.lib.ffmpeg import StreamMapper, Probe, Parser
 
 # Configure plugin logger
-logger = logging.getLogger("Unmanic.Plugin.remove_audio_stream_by_language")
+logger = logging.getLogger("Unmanic.Plugin.remove_stream_by_language")
 
 
 class Settings(PluginSettings):


### PR DESCRIPTION
Processes audio **and** subtitle streams. 

Uses negative stream selection in worker processing. ffmpeg will be in this style

copy everything, except Spanish streams
`ffmpeg -i input.mkv -map 0 -map -0:m:language:spa -c copy output.mkv`

Fixes #2